### PR TITLE
Add auth API tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "dev": "nodemon src/index.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,0 +1,49 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+
+const mockCreate = jest.fn().mockResolvedValue({ id: 1, email: 'test@example.com', role: 'volunteer' });
+const mockFindOne = jest.fn().mockResolvedValue({ id: 1, email: 'login@example.com', password: 'hashed', role: 'volunteer' });
+
+jest.unstable_mockModule('../src/models/User.js', () => ({
+  default: {
+    create: mockCreate,
+    findOne: mockFindOne
+  }
+}));
+
+jest.unstable_mockModule('bcrypt', () => ({
+  default: {
+    hash: async () => 'hashed',
+    compare: async () => true
+  }
+}));
+
+process.env.JWT_SECRET = 'testsecret';
+
+const authRoutesModule = await import('../src/routes/auth.js');
+
+const app = express();
+app.use(express.json());
+app.use('/api/auth', authRoutesModule.default);
+
+test('POST /api/auth/register returns 201', async () => {
+  const res = await request(app).post('/api/auth/register').send({
+    name: 'Test User',
+    email: 'test@example.com',
+    phone: '1234567890',
+    password: 'password',
+    role: 'volunteer'
+  });
+  expect(res.status).toBe(201);
+  expect(mockCreate).toHaveBeenCalled();
+});
+
+test('POST /api/auth/login returns 200', async () => {
+  const res = await request(app).post('/api/auth/login').send({
+    email: 'login@example.com',
+    password: 'password'
+  });
+  expect(res.status).toBe(200);
+  expect(mockFindOne).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add Jest script to backend/package.json
- test auth register and login endpoints using mocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684050916498832e917fc6693f78fdb0